### PR TITLE
feat: output option directory #12

### DIFF
--- a/.packito.json
+++ b/.packito.json
@@ -13,5 +13,6 @@
   },
   "publisher": {
     "name": "yarn test"
-  }
+  },
+  "output": "./dist"
 }

--- a/src/Packito.js
+++ b/src/Packito.js
@@ -71,13 +71,17 @@ export default class Packito {
 
   async write(packageFile = 'package.json') {
     let filehandle = null;
+    let outputDir = this.options ? this.options.output : undefined;
+    if (!outputDir) {
+      ({ outputDir } = this);
+    }
     try {
-      await fsp.mkdir(this.outputDir, { recursive: true });
+      await fsp.mkdir(outputDir, { recursive: true });
     } catch (error) {
       //
     }
     try {
-      const f = path.join(this.outputDir, packageFile);
+      const f = path.join(outputDir, packageFile);
       // TODO test if outputDir exist
       filehandle = await fsp.open(f, 'w');
       await filehandle.writeFile(this.data);

--- a/test/packito.test.js
+++ b/test/packito.test.js
@@ -89,7 +89,9 @@ describe('Packito', () => {
   it('write error', async () => {
     const p = new Packito();
     await p.write();
-    expect(p.error.message).to.equal(`The "path" argument must be of type string. Received type undefined`);
+    expect(
+      /^(The "path" argument must be of type string. Received){1}( type)?( undefined){1}/.test(p.error.message),
+    ).to.equal(true);
   });
 
   it('write to path', async () => {


### PR DESCRIPTION
### Fix issues

- [x] #12

### Description

See #12
We added an option:
```json
{
...
"output": "./dist"
}
```

### Check List

- [x] respect code conventions and usages
- [ ] tests and 100% coverage
- [x] well documented
- [x] self review

### Review targets:
- nodejs / npm / yarn