### PR TITLE
fix: use node cp function for more robust copying in packito

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -80,7 +80,7 @@ class PackitoCli {
       this.help();
     } else {
       // WIP execute
-      const packito = new Packito(args.dist, args.n, args._);
+      const packito = new Packito(args.dist, args.n, args._, this.output);
       await packito.transform();
       await packito.write();
       // this.log('args=', args);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,7 @@ describe('Cli', () => {
     expect(pcli).to.be.an('object');
     const { version } = getPackage('packito');
     expect(stack[0].indexOf(`Packito cleans package before publishing v${version}`) > -1).to.equal(true);
-    expect(stack.length).to.equal(21);
+    expect(stack.length).to.equal(23);
   });
   it('error', async () => {
     stack = [];


### PR DESCRIPTION
### Fix issues

Currently copying folders on macs when the destination folder doesn't exist yet results in the error "Error: ENOTSUP: operation not supported on socket, copyfile" The folder is definitely a folder, not a socket. This node bug pops up random places when anything with the filesystem is weird like symlinks, network shares, and in this case macos being weird.

### Description

- Now uses fs.cp to copy files and folders which is much more robust to weird files, folders and will properly follow symlinks.  - Will fallback to  fs.copyFile when fs.cp is unsupported (node < 16.7).
- Added log message when a copy error occurs

### Check List

- [ x ] respect code conventions and usages
- [ x ] tests and 100% coverage
- [ x ] well documented
- [ x ] self review

### Review targets:
- nodejs / npm / yarn


Thanks for making this handy tool!